### PR TITLE
Update tiledbsoma to track releases

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -16,6 +16,7 @@
     "maintainer": "Aaron Wolen <aaron@tiledb.com>",
     "url": "https://github.com/single-cell-data/TileDB-SOMA",
     "available": true,
+    "branch": "*release",
     "subdir": "apis/r"
   }
 ]


### PR DESCRIPTION
As discussed we've decided to update r-universe builds for tiledbsoma to track releases rather than updates to `main`. The package is maturing and we feel users would benefit from more explicit releases.

Context: https://github.com/single-cell-data/TileDB-SOMA/issues/1567