### PR TITLE
Update tiledb-r to track releases

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3,7 +3,8 @@
     "package": "tiledb",
     "maintainer": "Dirk Eddelbuettel <dirk@tiledb.com>",
     "url": "https://github.com/TileDB-Inc/TileDB-R",
-    "available": true
+    "available": true,
+    "branch": "*release"
   },
   {
     "package": "tiledbcloud",


### PR DESCRIPTION
tiledbsoma 1.4.0 requires tiledb-r >= 0.20.2 (built against TileDB 2.16.1). We won't be able to upload tiledb-r 0.20.2 to CRAN until they return from break on Aug 7. In the meantime, we can instruct users to install tiledb-r builds from R-universe, which already has 0.20.2 available.

This PR will temporarily instruct r-universe to only build tiledb-r releases, rather than the current `master` branch, ensuring SOMA users will only get a release build.

Once tiledb-r 0.20.2 is on CRAN, we can revert this PR.

Context: https://github.com/single-cell-data/TileDB-SOMA/issues/1567