### PR TITLE
Update `tiledbsoma-r` to track commits, only for today

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -17,7 +17,6 @@
     "maintainer": "Aaron Wolen <aaron@tiledb.com>",
     "url": "https://github.com/single-cell-data/TileDB-SOMA",
     "available": true,
-    "branch": "*release",
     "subdir": "apis/r"
   }
 ]


### PR DESCRIPTION
Context: https://github.com/single-cell-data/TileDB-SOMA/issues/1567

We want to test out recent commits to https://github.com/single-cell-data/TileDB-SOMA before tagging 1.4.0 in that repo