### PR TITLE
Pin 'tiledb-r' to its release 0.25.0 to effectuate a pin on Core

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -4,7 +4,7 @@
     "maintainer": "Dirk Eddelbuettel <dirk@tiledb.com>",
     "url": "https://github.com/TileDB-Inc/TileDB-R",
     "available": true,
-    "branch": "*release"
+    "branch": "0.25.0"
   },
   {
     "package": "tiledbcloud",


### PR DESCRIPTION
This is needed as a new and upcoming release of tiledb-r (say 0.26.0 next week) may move the Core library used by it forward to a new release, and ahead of the one used by tiledb-soma.  Given that we now test for equality, that would create a problem.

The combination of preventing an upgrade to a newer version by having tiledb-soma declare a '(<= X.Y.Z)' is one half of preventing this, providing an installable matching version is the other.

The line changed controls this.  The documentation at r-universe is a little sparse (and that is a problem, but one reference is in [this writeup under 'Pro-tip: tracking custom branches or releases'](https://ropensci.org/blog/2021/06/22/setup-runiverse/)). In essence 'branch' is passed on to remotes::install_github(repo, ref="HEAD") and becomes the 'ref' argument.  So _anything_ github recognises works here. I have used 'topic/branch' for branches, we can use '0.25.0' for a release that matches, and one can likely also pin to commit sha1 identifiers.

The burden, if any, is now to update this when the desired / required / preferred tiledb-r packages changes. The upside is that an _automatic_ upgrade to the newest release will not break tiledb-soma.