### PR TITLE
Use r-tiledb 0.27.0

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -4,7 +4,7 @@
     "maintainer": "Dirk Eddelbuettel <dirk@tiledb.com>",
     "url": "https://github.com/TileDB-Inc/TileDB-R",
     "available": true,
-    "branch": "0.26.0"
+    "branch": "0.27.0"
   },
   {
     "package": "tiledbcloud",


### PR DESCRIPTION
Following our [established procedure](https://github.com/single-cell-data/TileDB-SOMA/wiki/Branches-and-releases), as core 2.24.0 is out and so is `r-tiledb` 0.28.0.