### PR TITLE
Build tiledb-r 0.28.2

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -4,7 +4,7 @@
     "maintainer": "Dirk Eddelbuettel <dirk@tiledb.com>",
     "url": "https://github.com/TileDB-Inc/TileDB-R",
     "available": true,
-    "branch": "0.27.0"
+    "branch": "0.28.2"
   },
   {
     "package": "tiledbcloud",


### PR DESCRIPTION
tiledbsoma-r is still using core 2.24.2/tiledb-r 0.28.X; this PR updates tiledb-r to 0.28.2 which [builds with core 2.24.2](https://github.com/TileDB-Inc/TileDB-R/releases/tag/0.28.2)