### PR TITLE
Roll back hosted version of tiledb-r

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -4,7 +4,7 @@
     "maintainer": "Dirk Eddelbuettel <dirk@tiledb.com>",
     "url": "https://github.com/TileDB-Inc/TileDB-R",
     "available": true,
-    "branch": "0.30.0"
+    "branch": "0.29.0"
   },
   {
     "package": "tiledbcloud",


### PR DESCRIPTION
Roll back tiledb-r to 0.29.0 as the last released version of tiledbsoma-r still requires 0.29.0 instead of 0.30.0