### PR TITLE
Build latest development version of tiledb-r

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1,10 +1,7 @@
 [
   {
     "package": "tiledb",
-    "maintainer": "Dirk Eddelbuettel <dirk@tiledb.com>",
-    "url": "https://github.com/TileDB-Inc/TileDB-R",
-    "available": true,
-    "branch": "0.30.0"
+    "url": "https://github.com/TileDB-Inc/TileDB-R"
   },
   {
     "package": "tiledbcloud",


### PR DESCRIPTION
Now that tiledbsoma-r no longer has a maximal pin on tiledb-r single-cell-data/TileDB-SOMA#3006, switch to buidling the latest development version of tiledb-r (latest commit on `main`)