### PR TITLE
Provide `bit64` 4.5.2

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -28,5 +28,10 @@
     "maintainer": "Dirk Eddelbuettel <dirk@tiledb.com>",
     "url": "https://github.com/eddelbuettel/pbmc3k.tiledb",
     "available": true
+  },
+  {
+    "package": "bit64",
+    "url": "https://github.com/r-lib/bit64",
+    "branch": "4.5.2"
   }
 ]


### PR DESCRIPTION
https://github.com/single-cell-data/TileDB-SOMA/issues/3720
[[sc-63626]](https://app.shortcut.com/tiledb-inc/story/63626/tiledb-soma-1-16-0)