### PR TITLE
Host raw matrices for pbmc3k on r-universe

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -24,6 +24,12 @@
     "available": true
   },
   {
+    "package": "pbmc3k",
+    "maintainer": "Paul Hoffman <hoff0792@alumni.umn.edu>",
+    "url": "https://github.com/mojaveazure/pbmc3k/",
+    "available": true
+  },
+  {
     "package": "pbmc3k.tiledb",
     "maintainer": "Dirk Eddelbuettel <dirk@tiledb.com>",
     "url": "https://github.com/eddelbuettel/pbmc3k.tiledb",


### PR DESCRIPTION
The hosted SingleCellExperiment datasets are having some issues, so we want to host the raw matrices on R-universe and build the SCE objects in the test suite